### PR TITLE
Fix search bug

### DIFF
--- a/src/components/SearchApp/SearchApp.js
+++ b/src/components/SearchApp/SearchApp.js
@@ -179,7 +179,7 @@ function SearchApp(props) {
 
       <div className={styles.SearchResults}>
         {searchResults.map((value, index) => (
-          <SearchResult key={index} data={value} addToQueue={addToQueue}></SearchResult>
+          <SearchResult key={value.uuid} data={value} addToQueue={addToQueue}></SearchResult>
         ))}
       </div>
 


### PR DESCRIPTION
**Summary**

After adding an item to the queue, the "Add" button then becomes disabled.

**Example**

1: Search `hello`
2: Click "Add" on the first search result

**Result**

The "Add" button turns disabled and then has a checkmark instead of the word "Add."

... ok now the bug:

**Steps to Reproduce**

1: Search "Hello"
2: Click "Add" on the first search result
3: Search "World"

**Expected**

All of the search results should be enabled, none should be disabled with a checkmark.

**Observed**

The first search result is disabled.

**The Fix**

So I figured it out: the react component is using `UseState` to keep track of the disabled state.

Because the search result components are rendered in a loop, they are kept track via the `key` prop. The React render engine thinks the first search result is the same component both times it renders (first search and second search) because the `key` value is the same.

The fix here is to have the key be the `uuid` of the search result instead of index of the list.